### PR TITLE
Fix pip missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN set -ex \
                 py3-yaml \
                 py3-cryptography \
                 py3-decorator \
+                py-pip \
                 jpeg-dev \
                 zlib-dev
 


### PR DESCRIPTION
Add `py-pip` as a dependency. It seems not a dependency of installed packages. Without it the container can't be built.